### PR TITLE
Features/eba/change string format for sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,22 +43,22 @@ To describe the release naming process we will use the following nomenclature.
   * strips any characters that don't match - https://semver.org/#spec-item-9
   * We prefix BRANCH with `0.` to ensure it's the lowest version
 
-The default version for a branch is `NEXT_TAG-0.BRANCH-COMMITS+SHA`
+The default version for a branch is `NEXT_TAG-0.BRANCH-COMMITS-SHA`
 
 #### Tags
 
-When COMMITS is equal to 0 we assume the intent is to do a release of the current commit and the version will be the tag itself `TAG+SHA`
+When COMMITS is equal to 0 we assume the intent is to do a release of the current commit and the version will be the tag itself `TAG-SHA`
 
 *NOTE* Tags should be annotated tags and not lightweight tags.  Tags created in the Github UI will be lightweight tags by default.
 
 
 #### Master branch
 
-The master branch is treated differently from the default and will be `NEXT_TAG-COMMITS+SHA`
+The master branch is treated differently from the default and will be `NEXT_TAG-COMMITS-SHA`
 
 #### Integrated Support for Jenkins and PR branches
 
-Jenkins uses the environment variable BRANCH_NAME with the value of the PR example `PR-97`.  This will result in a release version of `NEXT_TAG-0.pr-97-COMMITS+SHA`
+Jenkins uses the environment variable BRANCH_NAME with the value of the PR example `PR-97`.  This will result in a release version of `NEXT_TAG-0.pr-97-COMMITS-SHA`
 
 ## Install without internet
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To describe the release naming process we will use the following nomenclature.
   * strips any characters that don't match - https://semver.org/#spec-item-9
   * We prefix BRANCH with `0.` to ensure it's the lowest version
 
-The default version for a branch is `NEXT_TAG-0.BRANCH-COMMITS-SHA+SHA`
+The default version for a branch is `NEXT_TAG-0.BRANCH-COMMITS-SHA`
 
 #### Tags
 
@@ -54,11 +54,11 @@ When COMMITS is equal to 0 we assume the intent is to do a release of the curren
 
 #### Master branch
 
-The master branch is treated differently from the default and will be `NEXT_TAG-COMMITS-SHA+SHA`
+The master branch is treated differently from the default and will be `NEXT_TAG-COMMITS+SHA`
 
 #### Integrated Support for Jenkins and PR branches
 
-Jenkins uses the environment variable BRANCH_NAME with the value of the PR example `PR-97`.  This will result in a release version of `NEXT_TAG-0.pr-97-COMMITS-SHA+SHA`
+Jenkins uses the environment variable BRANCH_NAME with the value of the PR example `PR-97`.  This will result in a release version of `NEXT_TAG-0.pr-97-COMMITS-SHA`
 
 ## Install without internet
 

--- a/README.md
+++ b/README.md
@@ -43,22 +43,22 @@ To describe the release naming process we will use the following nomenclature.
   * strips any characters that don't match - https://semver.org/#spec-item-9
   * We prefix BRANCH with `0.` to ensure it's the lowest version
 
-The default version for a branch is `NEXT_TAG-0.BRANCH-COMMITS-SHA`
+The default version for a branch is `NEXT_TAG-0.BRANCH-COMMITS-SHA+SHA`
 
 #### Tags
 
-When COMMITS is equal to 0 we assume the intent is to do a release of the current commit and the version will be the tag itself `TAG-SHA`
+When COMMITS is equal to 0 we assume the intent is to do a release of the current commit and the version will be the tag itself `TAG+SHA`
 
 *NOTE* Tags should be annotated tags and not lightweight tags.  Tags created in the Github UI will be lightweight tags by default.
 
 
 #### Master branch
 
-The master branch is treated differently from the default and will be `NEXT_TAG-COMMITS-SHA`
+The master branch is treated differently from the default and will be `NEXT_TAG-COMMITS-SHA+SHA`
 
 #### Integrated Support for Jenkins and PR branches
 
-Jenkins uses the environment variable BRANCH_NAME with the value of the PR example `PR-97`.  This will result in a release version of `NEXT_TAG-0.pr-97-COMMITS-SHA`
+Jenkins uses the environment variable BRANCH_NAME with the value of the PR example `PR-97`.  This will result in a release version of `NEXT_TAG-0.pr-97-COMMITS-SHA+SHA`
 
 ## Install without internet
 

--- a/git/git.go
+++ b/git/git.go
@@ -30,7 +30,7 @@ func New(directory string) (version.Getter, error) {
 }
 
 // ~r4.8-40-g56a99c2~
-//Doc: https://git-scm.com/docs/git-describe
+// Doc: https://git-scm.com/docs/git-describe
 func (g *Git) tag() (tag string, err error) {
 	tag, exists := os.LookupEnv("LAST_TAG")
 	if exists {

--- a/git/git.go
+++ b/git/git.go
@@ -197,7 +197,7 @@ func (g *Git) versionFromHistory(ver *semver.Version) (*semver.Version, error) {
 		}
 		version = version.IncPatch()
 		if branch != "master" {
-			prerel = "0." + branch + "-" + strconv.Itoa(commits)
+			prerel = "0." + branch
 		}
 	}
 

--- a/git/git.go
+++ b/git/git.go
@@ -197,7 +197,7 @@ func (g *Git) versionFromHistory(ver *semver.Version) (*semver.Version, error) {
 		}
 		version = version.IncPatch()
 		if branch != "master" {
-			prerel = "0." + branch
+			prerel = "0." + branch + "-" + sha
 		}
 	}
 

--- a/git/git.go
+++ b/git/git.go
@@ -217,9 +217,11 @@ func (g *Git) versionFromHistory(ver *semver.Version) (*semver.Version, error) {
 		}
 	}
 
-	version, err = version.SetMetadata(sha)
-	if err != nil {
-		return nil, err
+	if tagged || branch == "master" {
+		version, err = version.SetMetadata(sha)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &version, err
 }

--- a/helm/helm_test.go
+++ b/helm/helm_test.go
@@ -43,9 +43,9 @@ var versionTests = []struct {
 	{"master", "1.0.0", "0000001", "1", false, "1.0.1-1-0000001"},
 	{"master", "1.0.0", "0000002", "0", true, "1.0.0-0000002"},
 	{"master", "", "0000003", "1", false, "0.0.2-1-0000003"},
-	{"otherBranch", "1.0.0", "0000010", "1", false, "1.0.1-0.otherbranch-1-0000010"},
+	{"otherBranch", "1.0.0", "0000010", "1", false, "1.0.1-0.otherbranch-0000010"},
 	{"otherBranch", "1.0.0", "0000011", "0", true, "1.0.0-0000011"},
-	{"weird/branch$$other", "0.1.2", "0000020", "1", false, "0.1.3-0.weird.branch.other-1-0000020"},
+	{"weird/branch$$other", "0.1.2", "0000020", "1", false, "0.1.3-0.weird.branch.other-0000020"},
 	{"noversion", "", "0000030", "0", true, "0.0.1-0000030"},
 }
 

--- a/helm/helm_test.go
+++ b/helm/helm_test.go
@@ -40,13 +40,13 @@ var versionTests = []struct {
 	tagged   bool
 	expected string
 }{
-	{"master", "1.0.0", "0000001", "1", false, "1.0.1-1+0000001"},
-	{"master", "1.0.0", "0000002", "0", true, "1.0.0+0000002"},
-	{"master", "", "0000003", "1", false, "0.0.2-1+0000003"},
-	{"otherBranch", "1.0.0", "0000010", "1", false, "1.0.1-0.otherbranch+0000010"},
-	{"otherBranch", "1.0.0", "0000011", "0", true, "1.0.0+0000011"},
-	{"weird/branch$$other", "0.1.2", "0000020", "1", false, "0.1.3-0.weird.branch.other+0000020"},
-	{"noversion", "", "0000030", "0", true, "0.0.1+0000030"},
+	{"master", "1.0.0", "0000001", "1", false, "1.0.1-1-0000001"},
+	{"master", "1.0.0", "0000002", "0", true, "1.0.0-0000002"},
+	{"master", "", "0000003", "1", false, "0.0.2-1-0000003"},
+	{"otherBranch", "1.0.0", "0000010", "1", false, "1.0.1-0.otherbranch-1-0000010"},
+	{"otherBranch", "1.0.0", "0000011", "0", true, "1.0.0-0000011"},
+	{"weird/branch$$other", "0.1.2", "0000020", "1", false, "0.1.3-0.weird.branch.other-1-0000020"},
+	{"noversion", "", "0000030", "0", true, "0.0.1-0000030"},
 }
 
 func TestVersions(t *testing.T) {

--- a/helm/helm_test.go
+++ b/helm/helm_test.go
@@ -40,13 +40,13 @@ var versionTests = []struct {
 	tagged   bool
 	expected string
 }{
-	{"master", "1.0.0", "0000001", "1", false, "1.0.1-1-0000001"},
-	{"master", "1.0.0", "0000002", "0", true, "1.0.0-0000002"},
-	{"master", "", "0000003", "1", false, "0.0.2-1-0000003"},
-	{"otherBranch", "1.0.0", "0000010", "1", false, "1.0.1-0.otherbranch-0000010"},
-	{"otherBranch", "1.0.0", "0000011", "0", true, "1.0.0-0000011"},
-	{"weird/branch$$other", "0.1.2", "0000020", "1", false, "0.1.3-0.weird.branch.other-0000020"},
-	{"noversion", "", "0000030", "0", true, "0.0.1-0000030"},
+	{"master", "1.0.0", "0000001", "1", false, "1.0.1-1+0000001"},
+	{"master", "1.0.0", "0000002", "0", true, "1.0.0+0000002"},
+	{"master", "", "0000003", "1", false, "0.0.2-1+0000003"},
+	{"otherBranch", "1.0.0", "0000010", "1", false, "1.0.1-0.otherbranch-0000010+0000010"},
+	{"otherBranch", "1.0.0", "0000011", "0", true, "1.0.0+0000011"},
+	{"weird/branch$$other", "0.1.2", "0000020", "1", false, "0.1.3-0.weird.branch.other-0000020+0000020"},
+	{"noversion", "", "0000030", "0", true, "0.0.1+0000030"},
 }
 
 func TestVersions(t *testing.T) {

--- a/helm/helm_test.go
+++ b/helm/helm_test.go
@@ -43,9 +43,9 @@ var versionTests = []struct {
 	{"master", "1.0.0", "0000001", "1", false, "1.0.1-1+0000001"},
 	{"master", "1.0.0", "0000002", "0", true, "1.0.0+0000002"},
 	{"master", "", "0000003", "1", false, "0.0.2-1+0000003"},
-	{"otherBranch", "1.0.0", "0000010", "1", false, "1.0.1-0.otherbranch-0000010+0000010"},
+	{"otherBranch", "1.0.0", "0000010", "1", false, "1.0.1-0.otherbranch-0000010"},
 	{"otherBranch", "1.0.0", "0000011", "0", true, "1.0.0+0000011"},
-	{"weird/branch$$other", "0.1.2", "0000020", "1", false, "0.1.3-0.weird.branch.other-0000020+0000020"},
+	{"weird/branch$$other", "0.1.2", "0000020", "1", false, "0.1.3-0.weird.branch.other-0000020"},
 	{"noversion", "", "0000030", "0", true, "0.0.1+0000030"},
 }
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "release"
-version: "0.3.3"
+version: "0.3.4"
 usage: "Determines the charts next release number"
 description: |-
   This plugin will use environment variables and git history to divine the next chart version.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "release"
-version: "0.3.4"
+version: "0.3.5"
 usage: "Determines the charts next release number"
 description: |-
   This plugin will use environment variables and git history to divine the next chart version.


### PR DESCRIPTION
The customization is required so that the names are unique. The commit number alone is not sufficient:

1. the same commit numbers can exist twice (e.g. squash)
2. e.g. with Gitlab only a shallow pull is made and only a certain number of commits are loaded (e.g. 50) - then all builds have the number 50

So instead of using the commit number we will now use the commit-hash instead (just changing the "+" sign to a "-" sign).

Tickt Tool #332418